### PR TITLE
34 update GitHub actions to sync branch deletions

### DIFF
--- a/.github/workflows/git-sync.yml
+++ b/.github/workflows/git-sync.yml
@@ -4,7 +4,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: git-sync
-        uses: korvoj/git-sync@5eacd8ac78ae91a984f3aa430b09a0051abb2dc0
+        uses: korvoj/git-sync@branch-removal-debug
         with:
           source_repo: 'git@github.com:nmaas-platform/nmaas-platform.git'
           source_branch: 'refs/remotes/source/*'

--- a/.github/workflows/git-sync.yml
+++ b/.github/workflows/git-sync.yml
@@ -4,7 +4,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: git-sync
-        uses: korvoj/git-sync@branch-removal-debug
+        uses: korvoj/git-sync@branch-removal
         with:
           source_repo: 'git@github.com:nmaas-platform/nmaas-platform.git'
           source_branch: 'refs/remotes/source/*'


### PR DESCRIPTION
A forked version of https://github.com/wei/git-sync is used that can delete all branches in the destination repository which are not present in the source.